### PR TITLE
Upgrade peer dependendency on graphql-info/core to 0.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@popeindustries/lit-html-server": "^3.1.0"
   },
   "peerDependencies": {
-    "@graphql-info/core": "^0.0.1"
+    "@graphql-info/core": "^0.0.3"
   },
   "devDependencies": {
     "eslint": "^7.22.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@popeindustries/lit-html-server": "^3.1.0"
   },
   "peerDependencies": {
-    "@graphql-info/core": "^0.0.3"
+    "@graphql-info/core": "^0.0.4"
   },
   "devDependencies": {
     "eslint": "^7.22.0",


### PR DESCRIPTION
removes warning from OL yarn install. It also depends on merging in the marked PR in the /core package. The warning is actually incorrect because it meets the semver request already.